### PR TITLE
Modified slightly Band_by_Band test

### DIFF
--- a/FOOOF_unit/tests/test_band_by_band.py
+++ b/FOOOF_unit/tests/test_band_by_band.py
@@ -12,13 +12,6 @@ from capabilities.cap_ProducesPowerSpectrum import ProducesPowerSpectrum
 
 
 #FOOOF helper functions
-def compare_exp(fm1, fm2):
-    """Compare exponent values."""
-
-    exp1 = fm1.get_params('aperiodic_params', 'exponent')
-    exp2 = fm2.get_params('aperiodic_params', 'exponent')
-
-    return exp1 - exp2
 
 def compare_peak_pw(fm1, fm2, band_def):
     """Compare the power of detected peaks."""
@@ -27,6 +20,7 @@ def compare_peak_pw(fm1, fm2, band_def):
     pw2 = get_band_peak_fm(fm2, band_def)[1]
 
     return pw1 - pw2
+
 def compare_band_pw(fm1, fm2, band_def):
     """Compare the power of frequency band ranges."""
 
@@ -35,13 +29,14 @@ def compare_band_pw(fm1, fm2, band_def):
 
     return pw1 - pw2
 
-#Test class: in compute_score change the score depending on the FOOOF function of interest. In the following example with compare_band_pw
+#Test class: Have the option to select compare_peak_pw by intializing it with option=1. By default, compare_band_pw is used.
 class Band_by_Band(sciunit.Test):
   """Test giving a FloatScore which compares the power of frequency band ranges of the observation and the prediction model  """
 
-  def __init__(self, observation=None, name=None, band=None):
-    super().__init__(observation=observation, name=name, band=band)
+  def __init__(self, observation=None, name=None, band=None, option=None):
+    super().__init__(observation=observation, name=name, band=band, option=option)
     self.band = band
+    self.option = option
 
   required_capabilities = (ProducesPowerSpectrum,)
   score_type = FloatScore
@@ -62,6 +57,10 @@ class Band_by_Band(sciunit.Test):
     fm_pred.fit(prediction['freqs'], prediction['powers'], prediction['freq_range'])
 
     bands = Bands(self.band)
-    for label, definition in bands:
-      score = self.score_type((compare_band_pw(fm_pred, fm_obs, definition)))
+    if (self.option == 1):
+      for label, definition in bands:
+        score = self.score_type((compare_peak_pw(fm_pred, fm_obs, definition)))
+    else:
+      for label, definition in bands:
+        score = self.score_type((compare_band_pw(fm_pred, fm_obs, definition)))
     return score

--- a/FOOOF_unit/tests/test_band_by_band.py
+++ b/FOOOF_unit/tests/test_band_by_band.py
@@ -10,37 +10,21 @@ from fooof.utils import trim_spectrum
 from sciunit.scores import FloatScore
 from capabilities.cap_ProducesPowerSpectrum import ProducesPowerSpectrum
 
+    
+class _Band_by_Band(sciunit.Test):
+  """Test comparing the power of detected peaks or of frequency band ranges of the observation and the prediction model  """
 
-#FOOOF helper functions
-
-def compare_peak_pw(fm1, fm2, band_def):
-    """Compare the power of detected peaks."""
-
-    pw1 = get_band_peak_fm(fm1, band_def)[1]
-    pw2 = get_band_peak_fm(fm2, band_def)[1]
-
-    return pw1 - pw2
-
-def compare_band_pw(fm1, fm2, band_def):
-    """Compare the power of frequency band ranges."""
-
-    pw1 = np.mean(trim_spectrum(fm1.freqs, fm1.power_spectrum, band_def)[1])
-    pw2 = np.mean(trim_spectrum(fm1.freqs, fm2.power_spectrum, band_def)[1])
-
-    return pw1 - pw2
-
-#Test class: Have the option to select compare_peak_pw by intializing it with option=1. By default, compare_band_pw is used.
-class Band_by_Band(sciunit.Test):
-  """Test giving a FloatScore which compares the power of frequency band ranges of the observation and the prediction model  """
-
-  def __init__(self, observation=None, name=None, band=None, option=None):
-    super().__init__(observation=observation, name=name, band=band, option=option)
+  def __init__(self, observation=None, name=None, band=None):
+    super().__init__(observation=observation, name=name, band=band)
     self.band = band
-    self.option = option
 
   required_capabilities = (ProducesPowerSpectrum,)
   score_type = FloatScore
-
+    
+  def compare(self, fm1, fm2, band_def):
+    """Implemented in the subclasses"""
+    return NotImplementedError()
+    
   def generate_prediction(self, model):
     res = model.produce_power_spectrum()
     frequency = res[0]
@@ -57,10 +41,28 @@ class Band_by_Band(sciunit.Test):
     fm_pred.fit(prediction['freqs'], prediction['powers'], prediction['freq_range'])
 
     bands = Bands(self.band)
-    if (self.option == 1):
-      for label, definition in bands:
-        score = self.score_type((compare_peak_pw(fm_pred, fm_obs, definition)))
-    else:
-      for label, definition in bands:
-        score = self.score_type((compare_band_pw(fm_pred, fm_obs, definition)))
+    for label, definition in bands:
+      score = self.score_type((self.compare(fm_pred, fm_obs, definition)))
     return score
+
+
+class PeakPower(_Band_by_Band):
+
+  def compare(self, fm1, fm2, band_def):
+    """Compare the power of detected peaks."""
+
+    pw1 = get_band_peak_fm(fm1, band_def)[1]
+    pw2 = get_band_peak_fm(fm2, band_def)[1]
+
+    return pw1 - pw2
+
+
+class BandPower(_Band_by_Band):
+
+  def compare(self, fm1, fm2, band_def):
+    """Compare the power of frequency band ranges."""
+
+    pw1 = np.mean(trim_spectrum(fm1.freqs, fm1.power_spectrum, band_def)[1])
+    pw2 = np.mean(trim_spectrum(fm1.freqs, fm2.power_spectrum, band_def)[1])
+
+    return pw1 - pw2


### PR DESCRIPTION
Added the option of choosing between comparing the power of detected peaks or the power of frequency band ranges. While I was writing examples, I realized that this would make it easier for users to choose between the two instead of modifying the class each time. By default it will give the power of frequency band ranges. If option=1, then it will compute the power of detected peaks. This might be more clear with an example which I am currently working on for GitHub. For now, there is an example in the notebook new_band_by_band_comparison.ipynb (in FOOOF_tests). Let me know if this modification suits you.